### PR TITLE
EventDemand is now order aware

### DIFF
--- a/Classes/Domain/Model/Dto/EventDemand.php
+++ b/Classes/Domain/Model/Dto/EventDemand.php
@@ -20,7 +20,8 @@ namespace DWenzel\T3events\Domain\Model\Dto;
  */
 class EventDemand extends AbstractDemand
 	implements DemandInterface, PeriodAwareDemandInterface,
-	SearchAwareDemandInterface, AudienceAwareDemandInterface {
+	SearchAwareDemandInterface, AudienceAwareDemandInterface,
+    OrderAwareDemandInterface {
     // todo use demand traits
 	use PeriodAwareDemandTrait, SearchAwareDemandTrait,
 		AudienceAwareDemandTrait;


### PR DESCRIPTION
I noticed that I'm unable to sort events by anything using the settings in the plugin flexform.

Though some digging I found that the demand object has `sortby` and `order` while `sortby` is deprecated. However, the sorting of the flexform setting was only available though `sortBy` and `createQuery` only uses the `order`.

Some more digging and I found the AbstractDemandFactory which seems to set the `order` based on the plugins settings but only if the demand object implements `OrderAwareDemand`.

So there I am.