### PR TITLE
[BUGFIX] Fix relation between event and organizer in TCA of event table

### DIFF
--- a/Configuration/TCA/tx_t3events_domain_model_event.php
+++ b/Configuration/TCA/tx_t3events_domain_model_event.php
@@ -425,6 +425,7 @@ return [
                 'type' => 'group',
                 'internal_type' => 'db',
                 'allowed' => 'tx_t3events_domain_model_organizer',
+                'foreign_table' => 'tx_t3events_domain_model_organizer',
                 'l10nmode' => 'mergeIfNotBlank',
                 'size' => 1,
                 'default' => 0,


### PR DESCRIPTION
The TCA configuration for tx_t3events_domain_model_events.organizer currently does not set the `foreign_table` definition beneath the `allowed` configuration. As Extbase required both parameters to be set for type `group`, the `foreign_table` has been added.